### PR TITLE
Fix: Unable to save display order for warning definitions

### DIFF
--- a/upload/src/addons/SV/WarningImprovements/XF/Admin/Controller/Warning.php
+++ b/upload/src/addons/SV/WarningImprovements/XF/Admin/Controller/Warning.php
@@ -99,10 +99,12 @@ class Warning extends XFCP_Warning
 
         $categoryId = $this->filter('sv_warning_category_id', 'uint');
         $allowCustomTitle = $this->filter('sv_custom_title', 'bool');
+        $displayOrder = $this->filter('sv_display_order', 'uint');
 
         /** @var \SV\WarningImprovements\XF\Entity\WarningDefinition $warning */
         $warning->sv_warning_category_id = $categoryId;
         $warning->sv_custom_title = $allowCustomTitle;
+        $warning->sv_display_order = $displayOrder;
 
         return parent::warningSaveProcess($warning);
     }

--- a/upload/src/addons/SV/WarningImprovements/_output/templates/_metadata.json
+++ b/upload/src/addons/SV/WarningImprovements/_output/templates/_metadata.json
@@ -30,9 +30,9 @@
         "hash": "8678d18225e1323fe9da8dd43f8232c5"
     },
     "admin/sv_warning_edit_inputs.html": {
-        "version_id": 2000000,
-        "version_string": "2.0.0 Alpha",
-        "hash": "5feee680492c9869174aa470259b3f91"
+        "version_id": 2000001,
+        "version_string": "2.0.0rc1",
+        "hash": "1972d14996f83976a173de269f4d92f5"
     },
     "admin/sv_warning_improvements_action_tree_macros.html": {
         "version_id": 2000000,

--- a/upload/src/addons/SV/WarningImprovements/_output/templates/admin/sv_warning_edit_inputs.html
+++ b/upload/src/addons/SV/WarningImprovements/_output/templates/admin/sv_warning_edit_inputs.html
@@ -5,4 +5,4 @@
 	</xf:foreach>
 </xf:selectrow>
 
-<xf:numberboxrow name="sv_display_order" value="{$warning.sv_display_order}" min="0" step="10" label="{{ phrase('display_order:') }}" />
+<xf:macro template="display_order_macros" name="row" arg-name="sv_display_order" arg-value="{$warning.sv_display_order}" />


### PR DESCRIPTION
Bug report: https://xenforo.com/community/threads/warning-improvements-by-xon.143831/post-1229225