### PR TITLE
Remove can view permission check

### DIFF
--- a/upload/src/addons/SV/WarningImprovements/XF/Service/User/Warn.php
+++ b/upload/src/addons/SV/WarningImprovements/XF/Service/User/Warn.php
@@ -197,11 +197,6 @@ class Warn extends XFCP_Warn
     {
         $errors = parent::_validate();
 
-        if (!$this->warning->canView($error))
-        {
-            $errors[] = $error;
-        }
-
         return $errors;
     }
 


### PR DESCRIPTION
 This permission check creates a blank error for the issuer and prevents the warning if they don't have the view warning details permission when sending a warning.